### PR TITLE
Add configuration handler

### DIFF
--- a/src/main/java/salted/calmmornings/common/events/MobListEvents.java
+++ b/src/main/java/salted/calmmornings/common/events/MobListEvents.java
@@ -31,12 +31,13 @@ public class MobListEvents {
                 MobListUtils.addEntity(entity_id, entity);
             });
         }
+        MobListUtils.hydrateEntities(!Config.ENABLE_LIST.get());
     }
 
     @SubscribeEvent
     private static void configUpdated(ModConfigEvent.Reloading event) {
         if (Objects.equals(event.getConfig().getModId(), CalmMornings.MODID)) {
-            MobListUtils.hydrateEntities();
+            MobListUtils.hydrateEntities(!Config.ENABLE_LIST.get());
             CalmMornings.LOGGER.debug("config update event fired!");
         }
     }

--- a/src/main/java/salted/calmmornings/common/events/MobListEvents.java
+++ b/src/main/java/salted/calmmornings/common/events/MobListEvents.java
@@ -1,0 +1,43 @@
+package salted.calmmornings.common.events;
+
+import net.neoforged.fml.event.config.ModConfigEvent;
+import org.apache.logging.log4j.Marker;
+import org.apache.logging.log4j.MarkerManager;
+import salted.calmmornings.CalmMornings;
+import salted.calmmornings.common.Config;
+import salted.calmmornings.common.utils.DespawnUtils;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.resources.ResourceLocation;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.fml.event.lifecycle.FMLCommonSetupEvent;
+import salted.calmmornings.common.utils.MobListUtils;
+
+import java.util.Objects;
+import java.util.Set;
+
+@EventBusSubscriber(modid = CalmMornings.MODID, bus = EventBusSubscriber.Bus.MOD)
+public class MobListEvents {
+
+    @SubscribeEvent
+    private static void onStartup(FMLCommonSetupEvent event) {
+        Marker marker = MarkerManager.getMarker("[CalmMornings]");
+        Set<ResourceLocation> names = BuiltInRegistries.ENTITY_TYPE.keySet();
+        for (ResourceLocation loc : names) {
+            String entity_id = loc.toString();
+            EntityType.byString(entity_id).ifPresent(entity -> {
+                CalmMornings.LOGGER.debug(marker, "Adding entity " + entity_id + " to map");
+                MobListUtils.addEntity(entity_id, entity);
+            });
+        }
+    }
+
+    @SubscribeEvent
+    private static void configUpdated(ModConfigEvent.Reloading event) {
+        if (Objects.equals(event.getConfig().getModId(), CalmMornings.MODID)) {
+            MobListUtils.hydrateEntities();
+            CalmMornings.LOGGER.debug("config update event fired!");
+        }
+    }
+}

--- a/src/main/java/salted/calmmornings/common/utils/DespawnUtils.java
+++ b/src/main/java/salted/calmmornings/common/utils/DespawnUtils.java
@@ -11,14 +11,24 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.Vec3;
 import net.neoforged.fml.ModList;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import salted.calmmornings.CalmMornings;
 import salted.calmmornings.common.Config;
+import salted.calmmornings.common.utils.MobListUtils;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 
+
 public class DespawnUtils {
+    public static Logger log = LogManager.getLogger();
+
+    public static Logger getLog() { return log; }
+
 
     public static void despawnEntities(Level level, ServerPlayer player) {
         Difficulty difficulty = level.getDifficulty();
@@ -68,20 +78,14 @@ public class DespawnUtils {
     }
 
     private static boolean shouldDespawn(@NotNull Entity entity) {
+        log = getLog();
         EntityType<?> type = entity.getType();
-        String mobKey = EntityType.getKey(type).toString();
+        String[] mob_inf = EntityType.getKey(type).toString().split(":");
 
-        // see if the mob is in the list
-        if (Config.ENABLE_LIST.get()) {
-            if (Config.IS_BLACKLIST.get()) return !Config.MOB_LIST.get().contains(mobKey);
-            return Config.MOB_LIST.get().contains(mobKey);
-        }
-        // see if the mob is in the category, minus blacklisted ones
-        else if (!blackList.contains(type) && sleeptightCompat(type))  {
-            return type.getCategory().equals(MobCategory.MONSTER);
-        }
+        HashMap<String, HashMap<String, EntityDetails>> map = MobListUtils.getEntityMap();
 
-        return false;
+        if (blackList.contains(type)) return false;
+        return (map.get(mob_inf[0]).get(mob_inf[1]).getCategory() == MobCategory.MONSTER);
     }
 
     private static void despawn(@NotNull Entity entity) {

--- a/src/main/java/salted/calmmornings/common/utils/DespawnUtils.java
+++ b/src/main/java/salted/calmmornings/common/utils/DespawnUtils.java
@@ -51,25 +51,6 @@ public class DespawnUtils {
         }
     }
 
-    // private methods for despawning entities
-    // TODO: find a better way to do this
-    // a list of entities that should not be despawned
-    private static final ArrayList<EntityType<?>> blackList = new ArrayList<>(List.of(
-            // bosses/dungeon enemies
-            EntityType.ENDER_DRAGON,
-            EntityType.WITHER,
-            EntityType.GUARDIAN,
-            EntityType.ELDER_GUARDIAN,
-            /* this should prevent raids/roaming parties from being
-              affected, though there might be a better way to do this */
-            EntityType.PILLAGER,
-            EntityType.EVOKER,
-            EntityType.ILLUSIONER,
-            EntityType.RAVAGER,
-            // this shouldn't happen, but better safe than sorry
-            EntityType.PLAYER
-    ));
-
     // don't despawn bedbugs if mod is loaded
     private static boolean sleeptightCompat(EntityType<?> type) {
         String mobKey = EntityType.getKey(type).toString();
@@ -81,11 +62,14 @@ public class DespawnUtils {
         log = getLog();
         EntityType<?> type = entity.getType();
         String[] mob_inf = EntityType.getKey(type).toString().split(":");
+        String modId = mob_inf[0];
+        String entityId = mob_inf[1];
 
         HashMap<String, HashMap<String, EntityDetails>> map = MobListUtils.getEntityMap();
+        EntityDetails entityDetails = map.get(modId).get(entityId);
 
-        if (blackList.contains(type)) return false;
-        return (map.get(mob_inf[0]).get(mob_inf[1]).getCategory() == MobCategory.MONSTER);
+        if (Config.ENABLE_LIST.get()) return entityDetails.getDespawnable();
+        return (entityDetails.getCategory() == MobCategory.MONSTER && entityDetails.getDespawnable());
     }
 
     private static void despawn(@NotNull Entity entity) {

--- a/src/main/java/salted/calmmornings/common/utils/EntityDetails.java
+++ b/src/main/java/salted/calmmornings/common/utils/EntityDetails.java
@@ -1,0 +1,26 @@
+package salted.calmmornings.common.utils;
+
+import net.minecraft.world.entity.MobCategory;
+
+public class EntityDetails {
+    public MobCategory category;
+    public boolean despawnable;
+
+    EntityDetails(MobCategory c, boolean d) {
+        category = c;
+        despawnable = d;
+    }
+
+    public void setCategory(MobCategory c) {
+        this.category = c;
+    }
+
+    public void setDespawnable(boolean d) {
+        this.despawnable = d;
+    }
+
+    public MobCategory getCategory() { return this.category; }
+    public boolean getDespawnable() { return this.despawnable; }
+
+
+}

--- a/src/main/java/salted/calmmornings/common/utils/MobListUtils.java
+++ b/src/main/java/salted/calmmornings/common/utils/MobListUtils.java
@@ -15,6 +15,22 @@ import salted.calmmornings.common.Config;
 
 public final class MobListUtils {
 
+    private static final ArrayList<String> blackList = new ArrayList<>(List.of(
+            // bosses/dungeon enemies
+            "minecraft:ender_dragon",
+            "minecraft:wither",
+            "minecraft:guardian",
+            "minecraft:elder_guardian",
+            /* this should prevent raids/roaming parties from being
+              affected, though there might be a better way to do this */
+            "minecraft:pillager",
+            "minecraft:evoker",
+            "minecraft:illusioner",
+            "minecraft:ravager",
+            // this shouldn't happen, but better safe than sorry
+            "minecraft:player"
+    ));
+
     private static final HashMap<String, HashMap<String, EntityDetails>> entityMap = new HashMap<>();
 
     public static HashMap<String, HashMap<String, EntityDetails>> getEntityMap() { return entityMap; }
@@ -29,7 +45,9 @@ public final class MobListUtils {
         HashMap<String, EntityDetails> inner_map = new HashMap<>();
         // Check if we're running the default or if the config is enabled
         if (Config.ENABLE_LIST.get()) {
-            inner_map.put(entityId, new EntityDetails(type.getCategory(), Config.IS_BLACKLIST));
+            inner_map.put(entityId, new EntityDetails(type.getCategory(), Config.IS_BLACKLIST.get()));
+        } else {
+            inner_map.put(entityId, new EntityDetails(type.getCategory(), true));
         }
         // Get the mod map if it exists. If it doesn't create
         if (map.containsKey(modId)) {
@@ -39,15 +57,36 @@ public final class MobListUtils {
         }
     }
 
-    public static void hydrateEntities() {
-        boolean listEnabled = Config.ENABLE_LIST.get();
-        if (listEnabled) {
-            boolean isBlackList = Config.IS_BLACKLIST.get();
-            setAllEntities(isBlackList);
+    public static void hydrateEntities(boolean isDefault) {
+        HashMap<String, HashMap<String, EntityDetails>> map = getEntityMap();
+        if (isDefault) {
+            setAllEntities(true);
+            for (String entity : blackList) {
+                setMobDespawnValue(entity.split(":"), false, map);
+            }
         } else {
             List<? extends String> list = Config.MOB_LIST.get();
-
+            boolean isBlackList = Config.IS_BLACKLIST.get();
+            setAllEntities(isBlackList);
+            for (String entity : list) {
+                String[] split = entity.split(":");
+                if (split.length == 1) {
+                    setAllInModID(split[0], !isBlackList, map);
+                } else {
+                    setMobDespawnValue(split, !isBlackList, map);
+                }
+            }
         }
+    }
+
+    private static void setMobDespawnValue(String[] mobInf, boolean value, HashMap<String, HashMap<String, EntityDetails>> map) {
+        String modId = mobInf[0];
+        String entityId = mobInf[1];
+        map.get(modId).get(entityId).setDespawnable(value);
+    }
+
+    private static void setAllInModID(String modId, boolean value, HashMap<String, HashMap<String, EntityDetails>> map) {
+        map.get(modId).forEach((entityId, entityDetails) -> entityDetails.setDespawnable(value));
     }
 
     private static void setAllEntities(boolean value) {

--- a/src/main/java/salted/calmmornings/common/utils/MobListUtils.java
+++ b/src/main/java/salted/calmmornings/common/utils/MobListUtils.java
@@ -1,0 +1,57 @@
+package salted.calmmornings.common.utils;
+
+
+import net.minecraft.world.entity.EntityType;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import org.jetbrains.annotations.NotNull;
+import salted.calmmornings.common.Config;
+
+
+
+
+public final class MobListUtils {
+
+    private static final HashMap<String, HashMap<String, EntityDetails>> entityMap = new HashMap<>();
+
+    public static HashMap<String, HashMap<String, EntityDetails>> getEntityMap() { return entityMap; }
+
+    public static void addEntity(@NotNull String entity_name, EntityType<?> type) {
+        // Split the entity name from the item type
+        String[] split = entity_name.split(":");
+        String modId = split[0];
+        String entityId = split[1];
+        // Get hashmap
+        HashMap<String, HashMap<String, EntityDetails>> map = getEntityMap();
+        HashMap<String, EntityDetails> inner_map = new HashMap<>();
+        // Check if we're running the default or if the config is enabled
+        if (Config.ENABLE_LIST.get()) {
+            inner_map.put(entityId, new EntityDetails(type.getCategory(), Config.IS_BLACKLIST));
+        }
+        // Get the mod map if it exists. If it doesn't create
+        if (map.containsKey(modId)) {
+            map.get(modId).putAll(inner_map);
+        } else {
+            map.put(modId, inner_map);
+        }
+    }
+
+    public static void hydrateEntities() {
+        boolean listEnabled = Config.ENABLE_LIST.get();
+        if (listEnabled) {
+            boolean isBlackList = Config.IS_BLACKLIST.get();
+            setAllEntities(isBlackList);
+        } else {
+            List<? extends String> list = Config.MOB_LIST.get();
+
+        }
+    }
+
+    private static void setAllEntities(boolean value) {
+        HashMap<String, HashMap<String, EntityDetails>> entityMap = getEntityMap();
+        entityMap.forEach((modId, innerMap) -> { innerMap.forEach((entityId, entityDetails) -> entityDetails.setDespawnable(value));});
+    }
+}

--- a/src/main/java/salted/calmmornings/common/utils/TimeUtils.java
+++ b/src/main/java/salted/calmmornings/common/utils/TimeUtils.java
@@ -195,5 +195,4 @@ public class TimeUtils {
             return end;
         }
     }
-
 }


### PR DESCRIPTION
This adds a configuration handler that stores a list of all entities as a hashmap of mod ids and entity names. It enables you to blacklist or whitelist any loaded entity using their full resource ID or just the mod id.