### PR TITLE
Add mob category filters

### DIFF
--- a/src/main/java/salted/calmmornings/common/Config.java
+++ b/src/main/java/salted/calmmornings/common/Config.java
@@ -1,5 +1,6 @@
 package salted.calmmornings.common;
 
+import net.minecraft.world.entity.MobCategory;
 import net.neoforged.neoforge.common.ModConfigSpec;
 import salted.calmmornings.CalmMornings;
 import salted.calmmornings.common.utils.TimeUtils.Time;
@@ -7,9 +8,18 @@ import salted.calmmornings.common.utils.TimeUtils.Time;
 import java.util.ArrayList;
 import java.util.List;
 
+
 public class Config {
     public static ModConfigSpec COMMON_CONFIG;
     private static final List<String> defaultList = new ArrayList<>(List.of("minecraft:creeper", "minecraft:zombie", "minecraft:spider"));
+    // Configurable Entity Filters
+    public static ModConfigSpec.BooleanValue CREATURE;
+    public static ModConfigSpec.BooleanValue MONSTER;
+    public static ModConfigSpec.BooleanValue MISC;
+    public static ModConfigSpec.BooleanValue AMBIENT;
+    public static ModConfigSpec.BooleanValue WATER_CREATURE;
+    public static ModConfigSpec.BooleanValue UNDERGROUND_WATER_CREATURE;
+    public static ModConfigSpec.BooleanValue WATER_AMBIENT;
     public static ModConfigSpec.BooleanValue ENABLE_LIST;
     public static ModConfigSpec.BooleanValue IS_BLACKLIST;
     public static ModConfigSpec.ConfigValue<List<? extends String>> MOB_LIST;
@@ -21,6 +31,7 @@ public class Config {
     public static ModConfigSpec.BooleanValue PLAYER_CHECK;
     public static ModConfigSpec.BooleanValue MOB_CHECK;
     public static ModConfigSpec.BooleanValue BETTER_CHECKING;
+
 
     static {
         ModConfigSpec.Builder builder = new ModConfigSpec.Builder();
@@ -44,6 +55,7 @@ public class Config {
                         Formatting: ["minecraft:creeper", "minecraft:zombie", "minecraft:spider", "modID:entityID"]""")
                 .translation(modid + ".config." + "MOB_LIST").defineListAllowEmpty(List.of("mobs"), () -> defaultList, () -> "", mobs -> mobs instanceof String);
         builder.pop();
+
 
         String CATEGORY_RANGE = "range";
         builder.comment("Range Settings").translation(modid + ".config." + "CATEGORY_RANGE").push(CATEGORY_RANGE);
@@ -91,6 +103,18 @@ public class Config {
                 .comment("Should only monsters tracking the player prevent sleep? Requires monsterCheck.")
                 .translation(modid + ".config." + "BETTER_CHECKING")
                 .define("betterChecking", true);
+
+        // Mob Category Filter Settings
+        String MOB_CATEGORY_FILTER = "Mob Category Filter";
+        builder.comment("Mob Category Filter Settings").translation(modid + ".config." + "MOB_CATEGORY_FILTER").push(MOB_CATEGORY_FILTER);
+
+        CREATURE = builder.translation(modid + ".config." + "CREATURE").define("Creature", true);
+        MONSTER = builder.translation(modid + ".config." + "MONSTER").define("Monster", true);
+        AMBIENT = builder.translation(modid + ".config." + "AMBIENT").define("Ambient", false);
+        WATER_CREATURE = builder.translation(modid + ".config." + "WATER_CREATURE").define("Water Creature", false);
+        UNDERGROUND_WATER_CREATURE = builder.translation(modid + ".config." + "UNDERGROUND_WATER_CREATURE").define("Underground Water Creature", false);
+        WATER_AMBIENT = builder.translation(modid + ".config." + "WATER_AMBIENT").define("Water Ambient", false);
+        MISC = builder.translation(modid + ".config." + "MISC").define("Misc", false);
         builder.pop();
 
         COMMON_CONFIG = builder.build();

--- a/src/main/java/salted/calmmornings/common/entitylist/ListBuilder.java
+++ b/src/main/java/salted/calmmornings/common/entitylist/ListBuilder.java
@@ -2,19 +2,42 @@ package salted.calmmornings.common.entitylist;
 
 import net.minecraft.util.Tuple;
 import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.MobCategory;
 import org.jetbrains.annotations.NotNull;
 import salted.calmmornings.CalmMornings;
 import salted.calmmornings.common.Config;
 import salted.calmmornings.common.threading.ThreadManager;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
 public final class ListBuilder {
+
+    public static HashSet<MobCategory> filterList = new HashSet<>();
     public static List<String> getBlackList() { return blackList; }
+    public static HashSet<MobCategory> getFilterList() { return filterList; }
     public static ConcurrentHashMap<String, ConcurrentHashMap<String, ListInfo>> getEntityMap() { return entityMap; }
+
+    public static void updateFilterList() {
+        HashSet<MobCategory> filterList = getFilterList();
+        if (Config.CREATURE.getAsBoolean()) { filterList.add(MobCategory.CREATURE); }
+        else { filterList.remove(MobCategory.CREATURE); }
+        if (Config.MONSTER.getAsBoolean()) { filterList.add(MobCategory.MONSTER); }
+        else { filterList.remove(MobCategory.MONSTER); }
+        if (Config.AMBIENT.getAsBoolean()) { filterList.add(MobCategory.AMBIENT); }
+        else { filterList.remove(MobCategory.AMBIENT); }
+        if (Config.WATER_CREATURE.getAsBoolean()) { filterList.add(MobCategory.WATER_CREATURE); }
+        else { filterList.remove(MobCategory.WATER_CREATURE); }
+        if (Config.WATER_AMBIENT.getAsBoolean()) { filterList.add(MobCategory.WATER_AMBIENT); }
+        else { filterList.remove(MobCategory.WATER_AMBIENT); }
+        if (Config.UNDERGROUND_WATER_CREATURE.getAsBoolean()) { filterList.add(MobCategory.UNDERGROUND_WATER_CREATURE); }
+        else { filterList.remove(MobCategory.UNDERGROUND_WATER_CREATURE); }
+        if (Config.MISC.getAsBoolean()) { filterList.add(MobCategory.MISC); }
+        else { filterList.remove(MobCategory.MISC); }
+    }
 
     public static void addEntity(@NotNull String entity, EntityType<?> type) {
         // get modId and entityId if they exist

--- a/src/main/java/salted/calmmornings/common/events/EntityListEvents.java
+++ b/src/main/java/salted/calmmornings/common/events/EntityListEvents.java
@@ -38,6 +38,7 @@ public class EntityListEvents {
         manger.awaitShutdown(5);
 
         if (ModList.get().isLoaded("sleep_tight")) sleeptightCompat();
+        ListBuilder.updateFilterList();
         ListBuilder.configureEntities(Config.ENABLE_LIST.get());
     }
 
@@ -46,6 +47,7 @@ public class EntityListEvents {
         if (!Objects.equals(event.getConfig().getModId(), CalmMornings.MODID)) return;
         CalmMornings.LOGGER.debug("config update event fired!");
 
+        ListBuilder.updateFilterList();
         ListBuilder.configureEntities(Config.ENABLE_LIST.get());
     }
 

--- a/src/main/java/salted/calmmornings/common/utils/DespawnUtils.java
+++ b/src/main/java/salted/calmmornings/common/utils/DespawnUtils.java
@@ -17,6 +17,7 @@ import salted.calmmornings.common.Config;
 import salted.calmmornings.common.entitylist.ListBuilder;
 import salted.calmmornings.common.entitylist.ListInfo;
 
+import java.util.HashSet;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -57,7 +58,7 @@ public class DespawnUtils {
         ConcurrentHashMap<String, ConcurrentHashMap<String, ListInfo>> map = ListBuilder.getEntityMap();
         ListInfo listInfo = map.get(modId).get(entityId);
 
-        if (Config.ENABLE_LIST.get()) return listInfo.getDespawnable();
+        if (Config.ENABLE_LIST.get()) return listInfo.getDespawnable() && ListBuilder.getFilterList().contains(listInfo.getCategory());
         return (listInfo.getCategory() == MobCategory.MONSTER && listInfo.getDespawnable());
     }
 

--- a/src/main/resources/assets/calmmornings/lang/en_us.json
+++ b/src/main/resources/assets/calmmornings/lang/en_us.json
@@ -3,6 +3,15 @@
   "calmmornings.config.ENABLE_LIST": "Enable List",
   "calmmornings.config.IS_BLACKLIST": "Blacklist",
   "calmmornings.config.MOB_LIST": "Mobs",
+  "calmmornings.config.MOB_CATEGORY_FILTER": "Mob Category Filter",
+
+  "calmmornings.config.CREATURE": "Creature",
+  "calmmornings.config.MONSTER": "Monster",
+  "calmmornings.config.AMBIENT": "Ambient",
+  "calmmornings.config.WATER_CREATURE": "Water Creature",
+  "calmmornings.config.UNDERGROUND_WATER_CREATURE": "Underground Water Creature",
+  "calmmornings.config.WATER_AMBIENT": "Water Ambient",
+  "calmmornings.config.MISC": "Miscellaneous",
 
   "calmmornings.config.CATEGORY_RANGE": "Range Settings",
   "calmmornings.config.ENABLED_SCALING": "Enable Scaling",


### PR DESCRIPTION
Adds options in the configuration menu to only despawn entities that fall into certain mob categories. The code needs to be cleaned up but it should prevent unexpected behavior like TNT Minecarts despawning if the blacklist is enabled.